### PR TITLE
Refs #35: Add defaultHttpConfig to return default value of HttpConfig type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Future release
+
+* Added the `defaultHttpConfig` function to return the default value for the
+  `HttpConfig` type without requiring clients to depend on the `data-default`
+  package via the `Data.Default.Default` type class.
+
 ## Req 1.0.0
 
 * Added the `reqBr` function allowing to consume `Response BodyReader`

--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -122,6 +122,7 @@ module Network.HTTP.Req
     -- $embedding-requests
   , MonadHttp  (..)
   , HttpConfig (..)
+  , defaultHttpConfig
   , Req
   , runReq
     -- * Request
@@ -612,7 +613,13 @@ data HttpConfig = HttpConfig
   } deriving Typeable
 
 instance Default HttpConfig where
-  def = HttpConfig
+  def = defaultHttpConfig
+
+-- | The default HTTP configuration
+--
+-- @since TODO
+defaultHttpConfig :: HttpConfig
+defaultHttpConfig = HttpConfig
     { httpConfigProxy         = Nothing
     , httpConfigRedirectCount = 10
     , httpConfigAltManager    = Nothing


### PR DESCRIPTION
This change adds my proposed `defaultHttpConfig` function. It doesn't update any code examples to use it yet.