### PR TITLE
Use rigid types for schemes in parsing functions

### DIFF
--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -872,7 +872,7 @@ infixl 5 /:
 -- parameters that are returned as 'Option'. It does not parse method name
 -- or authentication info from given 'ByteString'.
 
-parseUrlHttp :: ByteString -> Maybe (Url 'Http, Option scheme)
+parseUrlHttp :: ByteString -> Maybe (Url 'Http, Option 'Http)
 parseUrlHttp url' = do
   url <- B.stripPrefix "http://" url'
   (host :| path, option) <- parseUrlHelper url
@@ -880,7 +880,7 @@ parseUrlHttp url' = do
 
 -- | Just like 'parseUrlHttp', but expects “https” scheme.
 
-parseUrlHttps :: ByteString -> Maybe (Url 'Https, Option scheme)
+parseUrlHttps :: ByteString -> Maybe (Url 'Https, Option 'Https)
 parseUrlHttps url' = do
   url <- B.stripPrefix "https://" url'
   (host :| path, option) <- parseUrlHelper url
@@ -893,7 +893,7 @@ parseUrlHttps url' = do
 
 parseUrl
   :: ByteString
-  -> Maybe (Either (Url 'Http, Option scheme) (Url 'Https, Option scheme))
+  -> Maybe (Either (Url 'Http, Option 'Http) (Url 'Https, Option 'Https))
 parseUrl url = Left <$> parseUrlHttp url <|> Right <$> parseUrlHttps url
 
 -- | Get host\/collection of path pieces and possibly query parameters


### PR DESCRIPTION
Sorry for the hassle, but I think there was a mistake in PR #49.

As the type signature for `parseUrl` has `scheme` type variable appearing twice, when using this function (at least from a higher order function) it gives an error about unmatched types:

```
 • Couldn't match type ‘'R.Http’ with ‘'R.Https’
      Expected type: Maybe
                       (Either
                          (R.Url 'R.Http, R.Option 'R.Http)
                          (R.Url 'R.Https, R.Option 'R.Https))
        Actual type: Maybe
                       (Either
                          (R.Url 'R.Http, R.Option 'R.Http)
                          (R.Url 'R.Https, R.Option 'R.Http))

```

I have fixed the type also in `parseUrlHttp` and `parseUrlHttps`, because I guess this should be the original intention, isn't it?