### PR TITLE
Add missing language extension on the examples

### DIFF
--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -311,6 +311,7 @@ import GHC.Exts (Constraint)
 -- First, this is a piece of boilerplate that should be in place before you
 -- try the examples:
 --
+-- > {-# LANGUAGE DeriveGeneric     #-}
 -- > {-# LANGUAGE OverloadedStrings #-}
 -- >
 -- > module Main (main) where


### PR DESCRIPTION
Hello, I noticed a small omission while running the examples.