### PR TITLE
Support HttpResponses adding Accept headers + add "Accept: application/json" to JsonResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## Unreleased
+## Req 2.2.0
 
 * Dropped support for GHC 7.10.
+
+* Added the new `acceptHeader` method to the `HttpResponse` type class.
+  Notably, the `jsonResponse` method now sets `"Accept"` header to
+  `"application/json"`.
 
 ## Req 2.0.1
 


### PR DESCRIPTION
Closes #63 
I am not sure about what tests to write (if any).

Another "major" thing is the use of `TypeApplications` + `AllowAmbiguousTypes` instead of a `Proxy`, but since the oldest supported ghc is `8.0.1` (which has both) it seemed fine to me.