### PR TITLE
Use ‘modern-uri’ for URL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## Unreleased
+## Req 3.0.0
+
+* Dropped functions `parseUrlHttp`, `parseUrlHttps`, and `parseUrl`. Instead
+  we now have `useHttpURI`, `useHttpsURI`, and `useURI` take `URI`s from
+  `modern-uri` as their argument. You first parse your URL with the
+  `modern-uri` package and then pass it to those functions. This allows us
+  to work with typed URI representations and seamlessly convert them to
+  something `req` can work with. As a side effect basic auth from the `URI`s
+  is now taken into consideration. In the future we may also start to
+  respect fragments if `http-client` starts to support this.
 
 * Dropped support for GHC 8.2 and older.
 

--- a/req.cabal
+++ b/req.cabal
@@ -38,6 +38,7 @@ library
                     , http-client      >= 0.5    && < 0.7
                     , http-client-tls  >= 0.3.2  && < 0.4
                     , http-types       >= 0.8    && < 10.0
+                    , modern-uri       >= 0.3    && < 0.4
                     , monad-control    >= 1.0    && < 1.1
                     , mtl              >= 2.0    && < 3.0
                     , retry            >= 0.8    && < 0.9
@@ -72,6 +73,7 @@ test-suite pure-tests
                     , hspec-core       >= 2.0    && < 3.0
                     , http-client      >= 0.5    && < 0.7
                     , http-types       >= 0.8    && < 10.0
+                    , modern-uri       >= 0.3    && < 0.4
                     , mtl              >= 2.0    && < 3.0
                     , req
                     , retry            >= 0.8    && < 0.9


### PR DESCRIPTION
Close #74, close #67.

The functions `parseUrlHttp`, `parseUrlHttps`, and `parseUrl` now take `URI`s from `modern-uri` as their argument. You first parse your URL with the `modern-uri` package and then pass it to those functions. This allows us to work with typed URI representations and seamlessly convert them to something `req` can work with.

TODO:

- [x] Make the tests pass and probably also add some new tests for basic auth. Improve/change the tests?
- [x] Maybe rename the functions? Now they do not really parse those `URI`. They just adapt, or maybe lift them to be used with `req`.