### PR TITLE
Allow for IO in httpConfigRetryPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Req 3.1.0
+
+* Changed signature of `httpConfigRetryPolicy` to `RetryPolicyM IO`.
+
 ## Req 3.0.0
 
 * Dropped functions `parseUrlHttp`, `parseUrlHttps`, and `parseUrl`. Instead

--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -596,7 +596,7 @@ data HttpConfig = HttpConfig
     -- /1.0.0/.
     --
     -- @since 0.3.0
-  , httpConfigRetryPolicy :: RetryPolicy
+  , httpConfigRetryPolicy :: RetryPolicyM IO
     -- ^ The retry policy to use for request retrying. By default 'def' is
     -- used (see 'RetryPolicyM').
     --


### PR DESCRIPTION
### Summary
Resolves https://github.com/mrkkrp/req/issues/55.

This change is backwards-compatible and shouldn't cause any downstream breakage.

LMK if you want me to do a version bump/changelog as well.

### Testing Done
`cabal new-build all` and `cabal new-test` both pass.

Validated in `ghci`

Before:
```
*Network.HTTP.Req Control.Retry> :t defaultHttpConfig { httpConfigRetryPolicy = fullJitterBackoff 100 }

<interactive>:1:45: error:
    • Could not deduce (MonadIO m)
        arising from a use of ‘fullJitterBackoff’
      from the context: Monad m
        bound by a type expected by the context:
                   RetryPolicy
        at <interactive>:1:1-67
      Possible fix:
        add (MonadIO m) to the context of
          a type expected by the context:
            RetryPolicy
    • In the ‘httpConfigRetryPolicy’ field of a record
      In the expression:
        defaultHttpConfig {httpConfigRetryPolicy = fullJitterBackoff 100}
```

After:
```
*Network.HTTP.Req Control.Retry> :t defaultHttpConfig { httpConfigRetryPolicy = fullJitterBackoff 100 }
defaultHttpConfig { httpConfigRetryPolicy = fullJitterBackoff 100 }
  :: HttpConfig
```