### PR TITLE
Add Quasiquoters for creating urls

### DIFF
--- a/req.cabal
+++ b/req.cabal
@@ -52,6 +52,7 @@ library
         monad-control >=1.0 && <1.1,
         mtl >=2.0 && <3.0,
         retry >=0.8 && <0.9,
+        template-haskell >=2.14 && <2.17,
         text >=0.2 && <1.3,
         time >=1.2 && <1.10,
         transformers >=0.4 && <0.6,


### PR DESCRIPTION
Adds two quasiquoters.

- `urlQ` which results in a value of type `Url 'Http` or `Url 'Https` and only accepts urls without anything requiring 'Option', like port or query parameters.
- `urlWithOptsQ` which results in a tuple `(Url 'Http|'Https, Option scheme)`. The `scheme` in `Option scheme` is independent of the input in accordance with the type of `useURI`.

Also I added a type role annotation for `scheme`. Without this GHC assumes that `scheme` is a phantom and it's safe to coerce between `Url 'Http` and `Url 'Https` and allows users to do so using `Data.Coerce.coerce`. The hope was that this would solve the problem with `lift` forgetting the scheme, however that was not the case. I still left it in (in a separate commit), because I thought it's a good idea regardless.