### PR TITLE
Derive ‘MonadThrow’, ‘MonadCatch’, and ‘MonadMask’ for ‘Req’

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Added `reqCb`, a function that allows you to modify the `Request` object
   but otherwise performs the requst for you.
 
+* Derived `MonadThrow`, `MonadCatch`, and `MonadMask` for the `Req` monad.
+
 ## Req 3.6.0
 
 * Added the `httpConfigBodyPreviewLength` configuration parameter to

--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -236,7 +237,7 @@ import Control.Applicative
 import Control.Arrow (first, second)
 import Control.Exception hiding (Handler (..), TypeError)
 import Control.Monad.Base
-import Control.Monad.Catch (Handler (..))
+import Control.Monad.Catch (Handler (..), MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
 import Control.Monad.Reader
@@ -775,6 +776,15 @@ newtype Req a = Req (ReaderT HttpConfig IO a)
       MonadIO,
       MonadUnliftIO
     )
+
+-- | @since 3.7.0
+deriving instance MonadThrow Req
+
+-- | @since 3.7.0
+deriving instance MonadCatch Req
+
+-- | @since 3.7.0
+deriving instance MonadMask Req
 
 instance MonadBase IO Req where
   liftBase = liftIO


### PR DESCRIPTION
Close #108.