### PR TITLE
Do not strip a trailing slash from URI path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Req 3.9.0
+
+* The `useHttpURI` and `useHttpsURI` functions now preserve trailing
+  slashes.
+
 ## Req 3.8.0
 
 * Adjusted the value of the `httpConfigRetryJudgeException` field of

--- a/pure-tests/Network/HTTP/ReqSpec.hs
+++ b/pure-tests/Network/HTTP/ReqSpec.hs
@@ -565,8 +565,9 @@ uriPort def uri =
 -- | Get path from 'URI'.
 uriPath :: URI -> ByteString
 uriPath uri = fromMaybe "" $ do
-  (_, xs) <- URI.uriPath uri
-  (return . encodePathPieces . fmap URI.unRText . NE.toList) xs
+  (trailingSlash, xs) <- URI.uriPath uri
+  let pref = (encodePathPieces . fmap URI.unRText . NE.toList) xs
+  return $ if trailingSlash then pref <> "/" else pref
 
 -- | Get query string from 'URI'.
 uriQuery :: URI -> ByteString


### PR DESCRIPTION
Some servers will interpret the path differently depending on if there
is a trailing slash or not. Example:

OK:  https://gerrit-review.googlesource.com/projects/?p=gerrit
404: https://gerrit-review.googlesource.com/projects?p=gerrit