### PR TITLE
Bump upper version bound of time package

### DIFF
--- a/req.cabal
+++ b/req.cabal
@@ -51,7 +51,7 @@ library
         retry >=0.8 && <0.10,
         template-haskell >=2.14 && <2.18,
         text >=0.2 && <1.3,
-        time >=1.2 && <1.10,
+        time >=1.2 && <1.13,
         transformers >=0.4 && <0.6,
         transformers-base,
         unliftio-core >=0.1.1 && <0.3


### PR DESCRIPTION
`cabal build` and `cabal test` both work. [Changelog](https://hackage.haskell.org/package/time-1.12/changelog) also seems innocuous - mostly instances and removing deprecated parsing functions.