### PR TITLE
Updates documentation for httpConfigRetryPolicy

### DIFF
--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -680,8 +680,8 @@ data HttpConfig = HttpConfig
     -- | The retry policy to use for request retrying. By default 'def' is
     -- used (see 'RetryPolicyM').
     --
-    -- __Note__: signature of this function was changed in the version
-    -- /1.0.0/.
+    -- __Note__: signature of this function was changed to disallow 'IO' in
+    -- version /1.0.0/ and then changed back to its current form in /3.1.0/.
     --
     -- @since 0.3.0
     httpConfigRetryPolicy :: RetryPolicyM IO,

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![Stackage LTS](http://stackage.org/package/req/badge/lts)](http://stackage.org/lts/package/req)
 ![CI](https://github.com/mrkkrp/req/workflows/CI/badge.svg?branch=master)
 
-* [Motivation and Req vs other libraries](#motivation-and-req-vs-other-libraries)
-* [Unsolved problems](#unsolved-problems)
 * [Related packages](#related-packages)
 * [Blog posts](#blog-posts)
 * [Contribution](#contribution)


### PR DESCRIPTION
Unsure what the best way to word this is, but it looks like this field type was [changed in 3.1.0](https://github.com/mrkkrp/req/blob/master/CHANGELOG.md#req-310) back to [its original, pre-1.0.0 form](https://github.com/mrkkrp/req/pull/33/files#diff-f0bf46b6fad1d6a79015114af845fb58bd4aadfa298c4b6dc135b4057668d5b4L551-R605).

I don't feel very strongly about this, I just remembered that the last time I had used the library `httpConfigRetryPolicy` had the type  `forall m. Monad m => RetryPolicy m`.

EDIT: Also noticed two sections from the table of contents that were removed in https://github.com/mrkkrp/req/commit/727a711a01dea7c22a14fc7c5facaeeb613c6a6f.