### PR TITLE
Enhancements about forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Req 3.11.0
+
+* Add the `queryParamToList` method to the `QueryParam` type class.
+* Add the `formToQuery` function. [Issue 126](https://github.com/mrkkrp/req/issues/126).
+* Add `FromForm` instances (in the `Web.FormUrlEncoded` module) to the
+  `Option` and `FormUrlEncodedParam` types.
+
 ## Req 3.10.0
 
 * Add `MonadHttp` instances for `transformers` types.

--- a/req.cabal
+++ b/req.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            req
-version:         3.10.0
+version:         3.11.0
 license:         BSD-3-Clause
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
@@ -83,6 +83,7 @@ test-suite pure-tests
         case-insensitive >=0.2 && <1.3,
         hspec >=2.0 && <3.0,
         hspec-core >=2.0 && <3.0,
+        http-api-data >=0.2 && <0.5,
         http-client >=0.7 && <0.8,
         http-types >=0.8 && <10.0,
         modern-uri >=0.3 && <0.4,


### PR DESCRIPTION
This pull-request includes the following.

- It adds `formToQuery` function.
- It adds `IsList` instance to `FormUrlEncodedParam`.
  - This makes it easy to inspect a `FormUrlEncodedParam` for testing purposes.
- It adds `FromForm` instance to `FormUrlEncodedParam` and `Option`.
  - Note that I didn't add `ToForm` instance, because `FormUrlEncodedParam` is more expressive than `Form`. The `toForm` function would cause loss of information.

This pull-request closes #126.
