### PR TITLE
Test with 3 latest versions of GHC, update Ormolu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         cabal: ["3.6"]
-        ghc: ["8.8.4", "8.10.7", "9.0.2"]
+        ghc: ["8.10.7", "9.0.1", "9.2.1"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks --flags=dev"
     steps:

--- a/req.cabal
+++ b/req.cabal
@@ -5,7 +5,7 @@ license:         BSD-3-Clause
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
 author:          Mark Karpov <markkarpov92@gmail.com>
-tested-with:     ghc ==8.8.4 ghc ==8.10.7 ghc ==9.0.2
+tested-with:     ghc ==8.10.7 ghc ==9.0.1 ghc ==9.2.1
 homepage:        https://github.com/mrkkrp/req
 bug-reports:     https://github.com/mrkkrp/req/issues
 synopsis:        HTTP client library
@@ -43,13 +43,13 @@ library
         exceptions >=0.6 && <0.11,
         http-api-data >=0.2 && <0.5,
         http-client >=0.7 && <0.8,
-        http-client-tls >=0.3.2 && <0.4,
+        http-client-tls >=0.3.6 && <0.4,
         http-types >=0.8 && <10.0,
         modern-uri >=0.3 && <0.4,
         monad-control >=1.0 && <1.1,
         mtl >=2.0 && <3.0,
         retry >=0.8 && <0.10,
-        template-haskell >=2.14 && <2.18,
+        template-haskell >=2.14 && <2.19,
         text >=0.2 && <1.3,
         time >=1.2 && <1.13,
         transformers >=0.5.3.0 && <0.6,
@@ -89,7 +89,7 @@ test-suite pure-tests
         mtl >=2.0 && <3.0,
         req,
         retry >=0.8 && <0.10,
-        template-haskell >=2.14 && <2.18,
+        template-haskell >=2.14 && <2.19,
         text >=0.2 && <1.3,
         time >=1.2 && <1.13
 


### PR DESCRIPTION
Continuation of #125; hs-memory has been updated, so this updates `http-client-tls` to a higher minimum version. Let's see if the tests pass now.