### PR TITLE
Allow text-2.0

### DIFF
--- a/req.cabal
+++ b/req.cabal
@@ -50,7 +50,7 @@ library
         mtl >=2.0 && <3.0,
         retry >=0.8 && <0.10,
         template-haskell >=2.14 && <2.19,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         time >=1.2 && <1.13,
         transformers >=0.5.3.0 && <0.6,
         transformers-base,
@@ -90,7 +90,7 @@ test-suite pure-tests
         req,
         retry >=0.8 && <0.10,
         template-haskell >=2.14 && <2.19,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         time >=1.2 && <1.13
 
     if flag(dev)
@@ -117,7 +117,7 @@ test-suite httpbin-tests
         monad-control >=1.0 && <1.1,
         mtl >=2.0 && <3.0,
         req,
-        text >=0.2 && <1.3
+        text >=0.2 && <2.1
 
     if flag(dev)
         ghc-options: -O0 -Wall -Werror


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' -w ghc-9.2.2
