### PR TITLE
Add StatusCodeException type and getStatusCodeException function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Req 3.12.0
+
+* Add `isStatusCodeException` function.
+* Add `instance HttpResponse (Network.HTTP.Client.Response ())`.
+
 ## Req 3.11.0
 
 * Add the `queryParamToList` method to the `QueryParam` type class.

--- a/httpbin-tests/Network/HTTP/ReqSpec.hs
+++ b/httpbin-tests/Network/HTTP/ReqSpec.hs
@@ -49,6 +49,11 @@ spec = do
         blindlyThrowing (req GET httpbin NoReqBody ignoreResponse mempty)
           `shouldThrow` anyException
 
+  describe "isStatusCodeException" $
+    it "extracts non-2xx response" $
+      req GET (httpbin /: "foo") NoReqBody ignoreResponse mempty
+        `shouldThrow` selector404ByStatusCodeException
+
   describe "receiving user-agent header back" $
     it "works" $ do
       r <-
@@ -453,6 +458,13 @@ selector404
     ) =
     L.responseStatus response == Y.status404 && not (B.null chunk)
 selector404 _ = False
+
+-- | Same as 'selector404' except that it uses 'isStatusCodeException'.
+selector404ByStatusCodeException :: HttpException -> Bool
+selector404ByStatusCodeException e =
+  case isStatusCodeException e of
+    Nothing -> False
+    Just r -> responseStatusCode r == 404
 
 -- | The empty JSON 'Object'.
 emptyObject :: Value


### PR DESCRIPTION
This pull-request adds `StatusCodeException` type and `getStatusCodeException` function. These are for convenience.

When I need to inspect the `HttpException`, in almost 100% cases I assume the exception is based on [`StatusCodeException`](https://hackage.haskell.org/package/http-client-0.7.11/docs/Network-HTTP-Client.html#t:HttpExceptionContent) and I need to inspect the status code and/or header in the response. However, to manually get `StatusCodeException` from `HttpException`, I need to unwrap three data constructors one by one. That is combersome, so I made this pull-request.

The new `StatusCodeException` type contains `IgnoreResponse` data type, instead of a vanilla `Response`. That way, we can use methods in `HttpResponse` type-class to inspect it.