### PR TITLE
mtl-2.3 compatibility

### DIFF
--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -217,11 +217,12 @@ import qualified Blaze.ByteString.Builder as BB
 import Control.Applicative
 import Control.Arrow (first, second)
 import Control.Exception hiding (Handler (..), TypeError)
+import Control.Monad (guard, void, (>=>))
 import Control.Monad.Base
 import Control.Monad.Catch (Handler (..), MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
-import Control.Monad.Reader
+import Control.Monad.Reader (ReaderT (ReaderT), ask, lift, runReaderT)
 import Control.Monad.Trans.Accum (AccumT)
 import Control.Monad.Trans.Cont (ContT)
 import Control.Monad.Trans.Control

--- a/httpbin-tests/Network/HTTP/ReqSpec.hs
+++ b/httpbin-tests/Network/HTTP/ReqSpec.hs
@@ -8,7 +8,7 @@
 module Network.HTTP.ReqSpec (spec) where
 
 import Control.Exception
-import Control.Monad.Reader
+import Control.Monad (forM_)
 import Control.Monad.Trans.Control
 import Data.Aeson (ToJSON (..), Value (..), object, (.=))
 import qualified Data.Aeson as A

--- a/req.cabal
+++ b/req.cabal
@@ -52,7 +52,7 @@ library
         template-haskell >=2.14 && <2.19,
         text >=0.2 && <2.1,
         time >=1.2 && <1.13,
-        transformers >=0.5.3.0 && <0.6,
+        transformers >=0.5.3.0 && <0.7,
         transformers-base,
         unliftio-core >=0.1.1 && <0.3
 


### PR DESCRIPTION
Fixes #135.

Tested with

    cabal test -w ghc-9.2.3 --constraint='transformers>=0.6' --allow-newer=authenticate-oauth:transformers

(this allow-newer is only necessary as long as yesodweb/authenticate#57 hasn't been released)

and

    cabal test -w ghc-8.8.4