### PR TITLE
Use better default TLS settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Req 3.13.4
+
+* Fixed empty ciphersuite list when compiling against `tls < 2.0.6`
+  (see [PR 175](https://github.com/mrkkrp/req/pull/175)). As a side effect, now
+  compatible with older versions of `crypton-connection` (>= 0.3).
+
 ## Req 3.13.3
 
 * Works with `crypton-connection-0.4` and newer.

--- a/Network/HTTP/Req.hs
+++ b/Network/HTTP/Req.hs
@@ -607,7 +607,7 @@ globalManager = unsafePerformIO $ do
   let settings =
         L.mkManagerSettingsContext
           (Just context)
-          (NC.TLSSettingsSimple False False False def)
+          def
           Nothing
   manager <- L.newManager settings
   newIORef manager

--- a/req.cabal
+++ b/req.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            req
-version:         3.13.3
+version:         3.13.4
 license:         BSD-3-Clause
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
@@ -40,7 +40,7 @@ library
         bytestring >=0.10.8 && <0.13,
         case-insensitive >=0.2 && <1.3,
         containers >=0.5 && <0.7,
-        crypton-connection >=0.4 && <0.5,
+        crypton-connection >=0.3 && <0.5,
         data-default-class,
         exceptions >=0.6 && <0.11,
         http-api-data >=0.2 && <0.7,


### PR DESCRIPTION
Commit message:

> On versions of tls pre-2.0.6, the default `Supported` had an empty list of `supportedCiphers`. Per discussion on [their issue][1], it seems like everyone was overriding it to `ciphersuite_default` anyway, hence the change at version 2.0.6 to make that default. But we're not doing that here!  Luckily, the [default for `TLSSettings`][2] does do that override, so we can use that to get the right behaviour regardless of tls version.

[1]: https://github.com/haskell-tls/hs-tls/pull/471
[2]: https://hackage.haskell.org/package/crypton-connection-0.4.0/docs/src/Network.Connection.Types.html#line-86

I noticed this because all my https requests were failing with this message:

```
(InternalException (HandshakeFailed (Error_Protocol ("expecting server hello, got alert : [(AlertLevel_Fatal,IllegalParameter)]",True,HandshakeFailure)))))
```

With this change, they succeed. (But they also succeed with the latest version of `tls`, which makes this difficult to write a regression test for.)