### PR TITLE
Pin data-default-class to >=0.2.0.0 and crypton-connection >=0.4.2 to avoid incompatibility issues

### DIFF
--- a/req.cabal
+++ b/req.cabal
@@ -40,7 +40,7 @@ library
         bytestring >=0.10.8 && <0.13,
         case-insensitive >=0.2 && <1.3,
         containers >=0.5 && <0.8,
-        crypton-connection >=0.3 && <0.5,
+        crypton-connection >=0.4.2 && <0.5,
         data-default-class >=0.2.0.0,
         exceptions >=0.6 && <0.11,
         http-api-data >=0.2 && <0.7,

--- a/req.cabal
+++ b/req.cabal
@@ -41,7 +41,7 @@ library
         case-insensitive >=0.2 && <1.3,
         containers >=0.5 && <0.8,
         crypton-connection >=0.3 && <0.5,
-        data-default-class,
+        data-default-class >=0.2.0.0,
         exceptions >=0.6 && <0.11,
         http-api-data >=0.2 && <0.7,
         http-client >=0.7.13.1 && <0.8,


### PR DESCRIPTION
Making sure that older versions of data-default-class aren't accepted, and make sure that we are using the crypton-connection version that works properly with this.

Technically this could be a cabal metadata update if you don't feel like a new PR.

Fixes #179.

Cheers!